### PR TITLE
Changes for remote schema

### DIFF
--- a/ddl/create.ddl
+++ b/ddl/create.ddl
@@ -13,7 +13,7 @@ DROP TABLE IF EXISTS fingerprints;
 DROP TABLE IF EXISTS repo_snapshots;
 
 CREATE TABLE repo_snapshots (
- id serial NOT NULL PRIMARY KEY,
+ id varchar NOT NULL PRIMARY KEY, -- we use the natural key for a repo here which is in this format that we use elsewhere in the wider graph. This allows us to use the repo-id to look into the wider graph and makes things more efficient
  workspace_id varchar NOT NULL,
  provider_id text NOT NULL,
  owner text NOT NULL,
@@ -22,9 +22,9 @@ CREATE TABLE repo_snapshots (
  branch text,
  path text,
  commit_sha varchar NOT NULL,
- analysis json,
+ analysis jsonb, -- we should move this to jsonb as it's going to be more versatile for us
  timestamp TIMESTAMP  NOT NULL,
- query text
+ query text -- currently missing in our db - will add this to our schema
 );
 
 -- One instance for each fingerprint
@@ -32,18 +32,21 @@ CREATE TABLE fingerprints (
   name text NOT NULL,
   feature_name text NOT NULL,
   sha varchar NOT NULL,
-  data json,
-  PRIMARY KEY (name, feature_name, sha)
+  data jsonb, -- also moved to jsonb for future use
+  id varchar NOT NULL PRIMARY KEY -- we have an id for fingerprints. This combines and creates a hash of name, feature_name and sha. 
+);
+
+CREATE TABLE IF NOT EXISTS repo_fingerprints (
+  repo_snapshot_id varchar references repo_snapshots(id),
+  fingerprint_id varchar references fingerprints(id),
+  PRIMARY KEY (repo_snapshot_id, fingerprint_id)
 );
 
 -- Join table
-CREATE TABLE repo_fingerprints (
-  repo_snapshot_id int references repo_snapshots(id),
-  name text NOT NULL,
-  feature_name text NOT NULL,
-  sha varchar NOT NULL,
-  PRIMARY KEY (repo_snapshot_id, name, feature_name, sha),
-  FOREIGN KEY (name, feature_name, sha) REFERENCES fingerprints (name, feature_name, sha)
+CREATE TABLE repo_fingerprints ( -- the two above id changes simplify this table
+  repo_snapshot_id varchar references repo_snapshots(id),
+  fingerprint_id varchar references fingerprints(id),
+  PRIMARY KEY (repo_snapshot_id, fingerprint_id)
 );
 
 CREATE TYPE severity AS ENUM ('error', 'warn');


### PR DESCRIPTION
@slimslenderslacks @johnsonr  These are the changes to converge the remote and local schemas.

The difference is largely that the keys we need to use are composed (hash based) keys that correspond to keys in other databases in the platform. Rather than using composite keys. I think we can use a similar approach in local mode and consolidate the two.

Let me know if you have any questions.