### PR TITLE
Change verbose messages to debug level

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -239,7 +239,7 @@ export const configuration: Configuration = configure(async sdm => {
 
                 // start up embedded postgres if needed
                 if (process.env.ATOMIST_POSTGRES === "start" && !_.get(cfg, "sdm.postgres")) {
-                    logger.info("Starting embedded Postgres");
+                    logger.debug("Starting embedded Postgres");
                     await execPromise("/etc/init.d/postgresql", ["start"]);
 
                     const postgresCfg = {

--- a/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
+++ b/lib/analysis/offline/persist/PostgresProjectAnalysisResultStore.ts
@@ -211,7 +211,7 @@ GROUP BY repo_snapshots.id`;
                 const fid = await this.ensureFingerprintStored(ideal.ideal, client);
                 await client.query(`INSERT INTO ideal_fingerprints (workspace_id, fingerprint_id, authority)
 values ($1, $2, 'local-user')`, [
-                    workspaceId, fid]);
+                        workspaceId, fid]);
             });
         } else {
             throw new Error("Elimination ideals not yet supported");
@@ -339,7 +339,7 @@ GROUP by repo_snapshots.id) stats;`;
         values ($1, $2, $3, $4, $5, $6)
         ON CONFLICT ON CONSTRAINT fingerprint_analytics_pkey DO UPDATE SET entropy = $4, variants = $5, count = $6`;
                 await client.query(sql, [kind.type, kind.name, workspaceId,
-                    cohortAnalysis.entropy, cohortAnalysis.variants, cohortAnalysis.count]);
+                cohortAnalysis.entropy, cohortAnalysis.variants, cohortAnalysis.count]);
             }
             return true;
         });
@@ -391,7 +391,7 @@ GROUP by repo_snapshots.id) stats;`;
             const repoSnapshotsInsertSql = `INSERT INTO repo_snapshots (id, workspace_id, provider_id, owner, name, url,
     commit_sha, analysis, query, timestamp)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, current_timestamp)`;
-            logger.info("Executing SQL:\n%s", repoSnapshotsInsertSql);
+            logger.debug("Executing SQL:\n%s", repoSnapshotsInsertSql);
             await client.query(repoSnapshotsInsertSql,
                 [id,
                     analysisResult.workspaceId,
@@ -469,7 +469,7 @@ VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`;
         // Create fp record if it doesn't exist
         const insertFingerprintSql = `INSERT INTO fingerprints (id, name, feature_name, sha, data)
 VALUES ($1, $2, $3, $4, $5) ON CONFLICT DO NOTHING`;
-        logger.info("Persisting fingerprint %j SQL\n%s", fp, insertFingerprintSql);
+        logger.debug("Persisting fingerprint %j SQL\n%s", fp, insertFingerprintSql);
         await client.query(insertFingerprintSql, [fingerprintId, fp.name, aspectName, fp.sha, JSON.stringify(fp.data)]);
         return fingerprintId;
     }
@@ -538,7 +538,7 @@ ORDER BY feature_name, fingerprintName ASC`;
                 path: row.path,
             };
         });
-        logger.info("%d fingerprints in workspace '%s'", fps.length, workspaceId);
+        logger.debug("%d fingerprints in workspace '%s'", fps.length, workspaceId);
         return fps;
     }, []);
 }

--- a/lib/analysis/offline/persist/pgUtils.ts
+++ b/lib/analysis/offline/persist/pgUtils.ts
@@ -54,7 +54,7 @@ export async function doWithClient<R>(description: string,
     } finally {
         client.release();
         const endTime = new Date().getTime();
-        logger.info("============= RDBMS operation ==================\n%s\n>>> Executed in %d milliseconds",
+        logger.debug("============= RDBMS operation ==================\n%s\n>>> Executed in %d milliseconds",
             description, endTime - startTime);
     }
     return result;

--- a/lib/analysis/offline/spider/Spider.ts
+++ b/lib/analysis/offline/spider/Spider.ts
@@ -101,8 +101,8 @@ export function logTimings(recorder: TimeRecorder): void {
         }));
     const totalSeconds = _.sum(timings.map(t => t.totalMillis)) / 1000;
     const sorted = _.sortBy(timings, t => -t.totalMillis);
-    logger.info("Aspect extraction total so far: %d seconds...", totalSeconds);
-    logger.info("\t" + sorted.map(s => `${s.name}: ${s.totalMillis / 1000} seconds`).join("\n\t"));
+    logger.debug("Aspect extraction total so far: %d seconds...", totalSeconds);
+    logger.debug("\t" + sorted.map(s => `${s.name}: ${s.totalMillis / 1000} seconds`).join("\n\t"));
 }
 
 /**

--- a/lib/analysis/offline/spider/local/LocalSpider.ts
+++ b/lib/analysis/offline/spider/local/LocalSpider.ts
@@ -57,7 +57,7 @@ export class LocalSpider implements Spider {
             results.push(await spiderOneLocalRepo(opts, criteria, analyzer, repoDir));
         }
 
-        logger.info("Computing analytics over all fingerprints...");
+        logger.debug("Computing analytics over all fingerprints...");
         await computeAnalytics(opts.persister, opts.workspaceId);
         return results.reduce(combineSpiderResults, emptySpiderResult);
     }

--- a/lib/machine/machine.ts
+++ b/lib/machine/machine.ts
@@ -66,7 +66,7 @@ export function updatedStoredAnalysisIfNecessary(opts: {
             const now = new Date();
             if (!found || !found.timestamp || now.getTime() - found.timestamp.getTime() > maxAgeMillis) {
                 const analysis = await opts.analyzer.analyze(pu.project);
-                logger.info("Performing fresh analysis of project at %s", pu.id.url);
+                logger.debug("Performing fresh analysis of project at %s", pu.id.url);
                 await opts.analyzedRepoStore.persist({
                     repoRef: analysis.id,
                     analysis,

--- a/lib/script/spider.ts
+++ b/lib/script/spider.ts
@@ -40,7 +40,6 @@ import {
     createAnalyzer,
     sdmConfigClientFactory,
 } from "../machine/machine";
-import { computeAnalytics } from "../analysis/offline/spider/analytics";
 import { Aspects } from "../customize/aspects";
 
 // Ensure we see console logging, and send info to the console
@@ -111,7 +110,7 @@ async function spider(params: SpiderAppOptions) {
     const arr = new Array<string>(JSON.stringify(criteria).length + 20);
     _.fill(arr, "-");
     const sep = arr.join("");
-    logger.info("%s\nOptions: %j\nSpider criteria: %j\n%s\n", sep, params, criteria, sep);
+    logger.debug("%s\nOptions: %j\nSpider criteria: %j\n%s\n", sep, params, criteria, sep);
     return spider.spider(criteria,
         analyzer,
         {
@@ -119,7 +118,7 @@ async function spider(params: SpiderAppOptions) {
             keepExistingPersisted: async existing => {
                 // Perform a computation here to return true if an existing analysis seems valid
                 const keep = !params.update;
-                logger.info(keep ?
+                logger.debug(keep ?
                     `Retaining existing analysis for ${existing.analysis.id.url}:${existing.analysis.id.sha}` :
                     `Recomputing analysis for ${existing.analysis.id.url}:${existing.analysis.id.sha}`);
                 return keep;

--- a/lib/tree/treeUtils.ts
+++ b/lib/tree/treeUtils.ts
@@ -203,9 +203,9 @@ export function introduceClassificationLayer<T = {}>(pt: PlantedTree,
         if (depth === (opts.newLayerDepth - 1) && isSunburstTree(node)) {
             // Split children
             const descendantsToClassifyBy = descendantPicker(node);
-            logger.info("Found %d leaves for %s", descendantsToClassifyBy.length, t.name);
+            logger.debug("Found %d leaves for %s", descendantsToClassifyBy.length, t.name);
             if (node === t && descendantsToClassifyBy.length === 0) {
-                logger.info("Nothing to do on %s", t.name);
+                logger.debug("Nothing to do on %s", t.name);
                 return false;
             }
             // Introduce a new node for each classification

--- a/lib/util/showTiming.ts
+++ b/lib/util/showTiming.ts
@@ -30,7 +30,7 @@ export async function showTiming<T>(description: string,
         return result;
     } finally {
         const endTime = new Date().getTime();
-        logger.info("Performed '%s' in %d milliseconds",
+        logger.debug("Performed '%s' in %d milliseconds",
             description, endTime - startTime);
     }
 }


### PR DESCRIPTION
This moves debug-style logging to DEBUG level.

@cdupuis how would one set the log to debug level for the spider?
Currently it configures it at the top of the script:
```
// Ensure we see console logging, and send info to the console
configureLogging(PlainLogging);
```

Is there a way to change the log level with, say, an env var? 
or later, after we parse the arguments?