### PR TITLE
Set authorization token only when present

### DIFF
--- a/lib/analysis/offline/spider/github/GitHubSpider.ts
+++ b/lib/analysis/offline/spider/github/GitHubSpider.ts
@@ -304,7 +304,7 @@ export interface GitHubSearchResult {
 
 async function* queryByCriteria(token: string, criteria: ScmSearchCriteria): AsyncIterable<GitHubSearchResult> {
     const octokit = new Octokit({
-        auth: "token " + token,
+        auth: token ? "token " + token : undefined,
         baseUrl: "https://api.github.com",
     });
     let results: any[] = [];


### PR DESCRIPTION
Prior to this commit the authorization header would be set to "token undefined" if it was not supplied causing spidering public repos to fail.  Now if the token is not set the auth header is omitted.